### PR TITLE
Extract init.lua customizations to lua/custom/plugins

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -960,12 +960,12 @@ require('lazy').setup({
   --  Here are some example plugins that I've included in the Kickstart repository.
   --  Uncomment any of the lines below to enable them (you will need to restart nvim).
   --
-  require 'kickstart.plugins.debug',
-  require 'kickstart.plugins.indent_line',
-  require 'kickstart.plugins.lint',
-  require 'kickstart.plugins.autopairs',
-  require 'kickstart.plugins.neo-tree',
-  require 'kickstart.plugins.gitsigns', -- adds gitsigns recommended keymaps
+  -- require 'kickstart.plugins.debug',
+  -- require 'kickstart.plugins.indent_line',
+  -- require 'kickstart.plugins.lint',
+  -- require 'kickstart.plugins.autopairs',
+  -- require 'kickstart.plugins.neo-tree',
+  -- require 'kickstart.plugins.gitsigns', -- adds gitsigns recommended keymaps
 
   -- NOTE: The import below can automatically add your own plugins, configuration, etc from `lua/custom/plugins/*.lua`
   --    This is the easiest way to modularize your config.

--- a/init.lua
+++ b/init.lua
@@ -728,17 +728,6 @@ require('lazy').setup({
         --
         -- You can use 'stop_after_first' to run the first available formatter from the list
         -- javascript = { "prettierd", "prettier", stop_after_first = true },
-
-        -- my customizations
-        json = { 'jq' },
-        sarif = { 'jq' },
-        python = { 'ruff_format', 'ruff_organize_imports' },
-        html = { 'prettier' },
-        javascript = { 'prettier' },
-        typescript = { 'prettier' },
-        typescriptreact = { 'prettier' },
-        markdown = { 'markdownlint' },
-        yaml = { 'prettier' },
       },
     },
   },

--- a/init.lua
+++ b/init.lua
@@ -798,7 +798,7 @@ require('lazy').setup({
         -- <c-k>: Toggle signature help
         --
         -- See :h blink-cmp-config-keymap for defining your own keymap
-        preset = 'super-tab',
+        preset = 'default',
 
         -- For more advanced Luasnip keymaps (e.g. selecting choice nodes, expansion) see:
         --    https://github.com/L3MON4D3/LuaSnip?tab=readme-ov-file#keymaps

--- a/init.lua
+++ b/init.lua
@@ -641,26 +641,6 @@ require('lazy').setup({
             Lua = {},
           },
         },
-
-        -- my customizations
-        clangd = {},
-        gopls = {},
-        pyright = {
-          settings = {
-            pyright = {
-              -- Using Ruff's import organizer
-              disableOrganizeImports = true,
-            },
-            python = {
-              analysis = {
-                -- Ignore all files for analysis to exclusively use Ruff for linting
-                ignore = { '*' },
-              },
-            },
-          },
-        },
-        ts_ls = {},
-        ruff = {},
       }
 
       -- Ensure the servers and tools above are installed
@@ -673,13 +653,6 @@ require('lazy').setup({
       local ensure_installed = vim.tbl_keys(servers or {})
       vim.list_extend(ensure_installed, {
         -- You can add other tools here that you want Mason to install
-
-        -- my customizations
-        'markdownlint',
-        'mypy',
-        'jq',
-        'prettier',
-        'codelldb',
       })
 
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }

--- a/lua/custom/plugins/blink-cmp.lua
+++ b/lua/custom/plugins/blink-cmp.lua
@@ -1,0 +1,6 @@
+return {
+  'saghen/blink.cmp',
+  opts = {
+    keymap = { preset = 'super-tab' },
+  },
+}

--- a/lua/custom/plugins/conform.lua
+++ b/lua/custom/plugins/conform.lua
@@ -1,0 +1,16 @@
+return {
+  'stevearc/conform.nvim',
+  opts = {
+    formatters_by_ft = {
+      json = { 'jq' },
+      sarif = { 'jq' },
+      python = { 'ruff_format', 'ruff_organize_imports' },
+      html = { 'prettier' },
+      javascript = { 'prettier' },
+      typescript = { 'prettier' },
+      typescriptreact = { 'prettier' },
+      markdown = { 'markdownlint' },
+      yaml = { 'prettier' },
+    },
+  },
+}

--- a/lua/custom/plugins/kickstart-enable.lua
+++ b/lua/custom/plugins/kickstart-enable.lua
@@ -1,0 +1,8 @@
+return {
+  require 'kickstart.plugins.debug',
+  require 'kickstart.plugins.indent_line',
+  require 'kickstart.plugins.lint',
+  require 'kickstart.plugins.autopairs',
+  require 'kickstart.plugins.neo-tree',
+  require 'kickstart.plugins.gitsigns',
+}

--- a/lua/custom/plugins/lsp.lua
+++ b/lua/custom/plugins/lsp.lua
@@ -1,16 +1,24 @@
+-- Pyright settings merge via vim.lsp.config deep-merge; mason-lspconfig's
+-- automatic_enable fires vim.lsp.enable() for each ensure_installed server.
 vim.lsp.config('pyright', {
   settings = {
-    pyright = { disableOrganizeImports = true },
-    python = { analysis = { ignore = { '*' } } },
+    pyright = {
+      -- Using Ruff's import organizer
+      disableOrganizeImports = true,
+    },
+    python = {
+      analysis = {
+        -- Ignore all files for analysis to exclusively use Ruff for linting
+        ignore = { '*' },
+      },
+    },
   },
 })
 
 return {
-  {
-    'mason-org/mason-lspconfig.nvim',
-    opts = {
-      ensure_installed = { 'clangd', 'gopls', 'pyright', 'ts_ls', 'ruff' },
-      automatic_enable = true,
-    },
+  'mason-org/mason-lspconfig.nvim',
+  opts = {
+    ensure_installed = { 'clangd', 'gopls', 'pyright', 'ts_ls', 'ruff' },
+    automatic_enable = true,
   },
 }

--- a/lua/custom/plugins/lsp.lua
+++ b/lua/custom/plugins/lsp.lua
@@ -1,0 +1,16 @@
+vim.lsp.config('pyright', {
+  settings = {
+    pyright = { disableOrganizeImports = true },
+    python = { analysis = { ignore = { '*' } } },
+  },
+})
+
+return {
+  {
+    'mason-org/mason-lspconfig.nvim',
+    opts = {
+      ensure_installed = { 'clangd', 'gopls', 'pyright', 'ts_ls', 'ruff' },
+      automatic_enable = true,
+    },
+  },
+}

--- a/lua/custom/plugins/mason-extras.lua
+++ b/lua/custom/plugins/mason-extras.lua
@@ -1,10 +1,11 @@
 vim.api.nvim_create_autocmd('User', {
-  pattern = 'VeryLazy', once = true,
+  pattern = 'VeryLazy',
+  once = true,
   callback = function()
     local mr = require 'mason-registry'
     mr.refresh(function()
-      local p = mr.get_package 'codelldb'
-      if not p:is_installed() then p:install() end
+      local ok, p = pcall(mr.get_package, 'codelldb')
+      if ok and not p:is_installed() then p:install() end
     end)
   end,
 })

--- a/lua/custom/plugins/mason-extras.lua
+++ b/lua/custom/plugins/mason-extras.lua
@@ -1,0 +1,12 @@
+vim.api.nvim_create_autocmd('User', {
+  pattern = 'VeryLazy', once = true,
+  callback = function()
+    local mr = require 'mason-registry'
+    mr.refresh(function()
+      local p = mr.get_package 'codelldb'
+      if not p:is_installed() then p:install() end
+    end)
+  end,
+})
+
+return {}


### PR DESCRIPTION
## Summary
- Move all fork-specific customizations out of `init.lua` into five new files under `lua/custom/plugins/` so merging from upstream kickstart only touches a single line.
- `init.lua` diff vs `upstream/master` is now exactly **one line**: the `{ import = 'custom.plugins' }` uncomment.
- Split tool sourcing: LSP servers + codelldb via Mason; `jq`, `prettier`, `markdownlint` from mise global. `mypy` dropped (unused in config).

## What moved where

| Customization | New file |
|---|---|
| `blink.cmp` `preset = 'super-tab'` | `lua/custom/plugins/blink-cmp.lua` |
| `conform.nvim` `formatters_by_ft` (9 filetypes) | `lua/custom/plugins/conform.lua` |
| 6 kickstart optional plugin enables (`debug`, `indent_line`, `lint`, `autopairs`, `neo-tree`, `gitsigns`) | `lua/custom/plugins/kickstart-enable.lua` |
| LSP servers (`clangd`, `gopls`, `pyright`, `ts_ls`, `ruff`) + pyright's Ruff-delegation settings | `lua/custom/plugins/lsp.lua` |
| `codelldb` auto-install (ships as `.vsix`, can't go through mise) | `lua/custom/plugins/mason-extras.lua` |

## Mechanisms
- `blink-cmp.lua` / `conform.lua` rely on **lazy.nvim's `opts` deep-merge** across duplicate plugin specs.
- `lsp.lua` adds a second spec for `mason-lspconfig.nvim` (kickstart declares it as a bare dep), triggering `setup(opts)` with `ensure_installed` + `automatic_enable = true`. `vim.lsp.config('pyright', ...)` runs as a top-level side effect during spec import, before mason-lspconfig enables pyright.
- `mason-extras.lua` uses a `User VeryLazy` autocmd + `mason-registry` API to install `codelldb` once.

## Docs
- Design spec: `docs/superpowers/specs/2026-04-14-nvim-config-refactor-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-14-extract-customizations.md`

(These are currently untracked; let me know if you want them committed on a follow-up.)

## Test plan
- [x] `nvim` starts cleanly (`:messages` empty)
- [x] `:Lazy` lists all expected plugins
- [x] `:checkhealth vim.lsp` shows `clangd` / `gopls` / `pyright` / `ts_ls` / `ruff` attached on relevant filetypes
- [x] Pyright settings: `:lua =vim.lsp.get_clients({name='pyright'})[1].config.settings` includes `disableOrganizeImports` and `ignore = { '*' }`
- [x] `:Mason` lists `lua_ls`, `stylua`, and (after startup) `codelldb`
- [x] `$PATH` inside nvim finds `jq`, `prettier`, `markdownlint` from mise
- [x] `<Tab>` accepts a `blink.cmp` completion
- [x] `<leader>f` formats JSON / Python / YAML / markdown / TS files
- [x] `]c` jumps to next gitsigns hunk on a modified file
- [x] `git diff upstream/master HEAD -- init.lua` shows only the `{ import = 'custom.plugins' }` uncomment