### PR TITLE
Merge upstream 2026-07

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,9 +10,11 @@ assignees: ''
 <!-- Any bug report not following this template will be immediately closed. Thanks -->
 
 ## Before Reporting an Issue
+
 - I have read the kickstart.nvim README.md.
 - I have read the appropriate plugin's documentation.
 - I have searched that this issue has not been reported before.
+- I have ran `:checkhealth` and so no obvious issue.
 
 - [ ] **By checking this, I confirm that the above steps are completed. I understand leaving this unchecked will result in this report being closed immediately.**
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Help
+    url: https://github.com/nvim-lua/kickstart.nvim/discussions/categories/q-a
+    about: Ask the community for help
+
+  - name: Ideas
+    url: https://github.com/nvim-lua/kickstart.nvim/discussions/categories/ideas
+    about: Share ideas for new features

--- a/init.lua
+++ b/init.lua
@@ -85,7 +85,7 @@ P.S. You can delete this when you're done too. It's your config now! :)
 --]]
 
 -- ============================================================
--- SECTION 1: FOUNDATION
+-- SECTION 1: OPTIONS
 -- Core Neovim settings, leaders, options, basic keymaps, basic autocmds
 -- ============================================================
 do
@@ -171,7 +171,13 @@ do
   -- instead raise a dialog asking if you wish to save the current file(s)
   -- See `:help 'confirm'`
   vim.o.confirm = true
+end
 
+-- ============================================================
+-- SECTION 2: KEYMAPS
+-- basic keymaps
+-- ============================================================
+do
   -- [[ Basic Keymaps ]]
   --  See `:help vim.keymap.set()`
 
@@ -248,7 +254,7 @@ do
 end
 
 -- ============================================================
--- SECTION 2: PLUGIN MANAGER INTRO
+-- SECTION 3: PLUGIN MANAGER INTRO
 -- vim.pack intro, build hooks
 -- ============================================================
 do
@@ -320,7 +326,7 @@ end
 local function gh(repo) return 'https://github.com/' .. repo end
 
 -- ============================================================
--- SECTION 3: UI / CORE UX PLUGINS
+-- SECTION 4: UI / CORE UX PLUGINS
 -- guess-indent, gitsigns, which-key, colorscheme, todo-comments, mini modules
 -- ============================================================
 do
@@ -444,7 +450,7 @@ do
 end
 
 -- ============================================================
--- SECTION 4: SEARCH & NAVIGATION
+-- SECTION 5: SEARCH & NAVIGATION
 -- Telescope setup, keymaps, LSP picker mappings
 -- ============================================================
 do
@@ -579,7 +585,7 @@ do
 end
 
 -- ============================================================
--- SECTION 5: LSP
+-- SECTION 6: LSP
 -- LSP keymaps, server configuration, Mason tools installations
 -- ============================================================
 do
@@ -765,7 +771,7 @@ do
 end
 
 -- ============================================================
--- SECTION 6: FORMATTING
+-- SECTION 7: FORMATTING
 -- conform.nvim setup and keymap
 -- ============================================================
 do
@@ -803,7 +809,7 @@ do
 end
 
 -- ============================================================
--- SECTION 7: AUTOCOMPLETE & SNIPPETS
+-- SECTION 8: AUTOCOMPLETE & SNIPPETS
 -- blink.cmp and luasnip setup
 -- ============================================================
 do
@@ -885,7 +891,7 @@ do
 end
 
 -- ============================================================
--- SECTION 8: TREESITTER
+-- SECTION 9: TREESITTER
 -- Parser installation, syntax highlighting, folds, indentation
 -- ============================================================
 do
@@ -947,7 +953,7 @@ do
 end
 
 -- ============================================================
--- SECTION 9: OPTIONAL EXAMPLES / NEXT STEPS
+-- SECTION 10: OPTIONAL EXAMPLES / NEXT STEPS
 -- kickstart.plugins.* examples
 -- ============================================================
 do

--- a/init.lua
+++ b/init.lua
@@ -581,7 +581,7 @@ do
   )
 
   -- Shortcut for searching your Neovim configuration files
-  vim.keymap.set('n', '<leader>sn', function() builtin.find_files { cwd = vim.fn.stdpath 'config' } end, { desc = '[S]earch [N]eovim files' })
+  vim.keymap.set('n', '<leader>sn', function() builtin.find_files { cwd = vim.fn.stdpath 'config', follow = true } end, { desc = '[S]earch [N]eovim files' })
 end
 
 -- ============================================================

--- a/init.lua
+++ b/init.lua
@@ -346,13 +346,6 @@ do
   vim.pack.add { gh 'NMAC427/guess-indent.nvim' }
   require('guess-indent').setup {}
 
-  -- Because lua is a real programming language, you can also have some logic to your installation -
-  -- like only installing a plugin if a condition is met.
-  --
-  -- Here we only install `nvim-web-devicons` (which adds pretty icons) if we have a Nerd Font,
-  -- since otherwise the icons won't display properly.
-  if vim.g.have_nerd_font then vim.pack.add { gh 'nvim-tree/nvim-web-devicons' } end
-
   -- Here is a more advanced configuration example that passes options to `gitsigns.nvim`
   --
   -- See `:help gitsigns` to understand what each configuration key does.
@@ -409,6 +402,13 @@ do
   -- [[ mini.nvim ]]
   --  A collection of various small independent plugins/modules
   vim.pack.add { gh 'nvim-mini/mini.nvim' }
+
+  -- If a nerd font is available, load the icons module for pretty icons in various plugins.
+  if vim.g.have_nerd_font then
+    require('mini.icons').setup()
+    -- Used for backwards compatibility with plugins that require `nvim-web-devicons` (e.g. telescope.nvim)
+    MiniIcons.mock_nvim_web_devicons()
+  end
 
   -- Better Around/Inside textobjects
   --

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -5,8 +5,8 @@
 
 -- Iterate over all Lua files in the plugins directory and load them
 local plugins_dir = vim.fs.joinpath(vim.fn.stdpath 'config', 'lua', 'custom', 'plugins')
-for file_name, type in vim.fs.dir(plugins_dir) do
-  if type == 'file' and file_name:match '%.lua$' and file_name ~= 'init.lua' then
+for file_name, type in vim.fs.dir(plugins_dir, { follow = true }) do
+  if (type == 'file' or type == 'link') and file_name:match '%.lua$' and file_name ~= 'init.lua' then
     local module = file_name:gsub('%.lua$', '')
     require('custom.plugins.' .. module)
   end

--- a/lua/custom/plugins/lspsaga.lua
+++ b/lua/custom/plugins/lspsaga.lua
@@ -1,5 +1,6 @@
--- nvim-treesitter is added by init.lua; nvim-web-devicons is also added there
--- (conditional on have_nerd_font, which we set to true).
+-- nvim-treesitter is added by init.lua. Icon support comes from mini.icons
+-- (also set up in init.lua), which mocks nvim-web-devicons for plugins like
+-- this one that require it (conditional on have_nerd_font, which we set to true).
 
 vim.pack.add { 'https://github.com/nvimdev/lspsaga.nvim' }
 

--- a/lua/kickstart/plugins/neo-tree.lua
+++ b/lua/kickstart/plugins/neo-tree.lua
@@ -1,17 +1,11 @@
 -- Neo-tree is a Neovim plugin to browse the file system
 -- https://github.com/nvim-neo-tree/neo-tree.nvim
 
-local plugins = {
+vim.pack.add {
   { src = 'https://github.com/nvim-neo-tree/neo-tree.nvim', version = vim.version.range '*' },
   'https://github.com/nvim-lua/plenary.nvim',
   'https://github.com/MunifTanjim/nui.nvim',
 }
-
-if vim.g.have_nerd_font then
-  table.insert(plugins, 'https://github.com/nvim-tree/nvim-web-devicons') -- not strictly required, but recommended
-end
-
-vim.pack.add(plugins)
 
 vim.keymap.set('n', '\\', '<Cmd>Neotree reveal<CR>', { desc = 'NeoTree reveal', silent = true })
 


### PR DESCRIPTION
Merges 8 commits from `nvim-lua/kickstart.nvim` master (through f0a2108).

## Upstream changes
- Switch from nvim-web-devicons to mini.icons (with `mock_nvim_web_devicons()` for compatibility)
- Split the `foundation` init.lua section into `options` and `keymaps` (sections renumbered)
- Follow symlinks in the custom plugins loader and the `<leader>sn` config picker
- Add checkhealth to the bug report template; add discussions link to issue templates

## Conflict resolution
- `lua/custom/plugins/init.lua` — kept HEAD (our ordered loader); upstream's change was symlink-following in their directory-scan loader, which doesn't apply to our explicit require list
- `init.lua` auto-merged; all personal lines preserved (nerd font, relativenumber, super-tab preset, prefer_rust fuzzy, custom.plugins hook)

## Follow-up
- Updated the stale comment in `lua/custom/plugins/lspsaga.lua`: icon support now comes from mini.icons' devicons mock rather than a real nvim-web-devicons install

Headless smoke-test passes: `nvim --headless "+lua print('config loaded ok')" "+qa"`